### PR TITLE
fix deprication warning for Regex /r

### DIFF
--- a/lib/networking/subsystem.ex
+++ b/lib/networking/subsystem.ex
@@ -118,9 +118,9 @@ defmodule Nerves.Networking.Subsystem do
   # responses to select the last (most relelvant) response, and convert to Dict
   # form
   defp parse_udhcpc_response(response) do
-    case (Regex.scan ~r/\[.*\]/sr, response) do
+    case (Regex.scan ~r/\[.*\]/sU, response) do
       [_, [last_response]] ->
-        Regex.scan(~r/(\w+='.+')\n/r, last_response)
+        Regex.scan(~r/(\w+='.+')\n/U, last_response)
         |> Enum.map(&cleanup_kv/1)
       _ ->
         Logger.error "#{__MODULE__} udhcpc invalid response: #{response}" 

--- a/test/mocks/udhcpc.exs
+++ b/test/mocks/udhcpc.exs
@@ -40,8 +40,8 @@ defmodule Mocks.UDHCPC do
 
   # makes the assumption we have an interfacename and hostname passed
   def udhcpc <<"-n -q -f -s /tmp/udhcpc.sh ", args :: binary>> do
-    [[_, interface]] = Regex.scan ~r/--interface=(\w+) /r,args
-    [[_, hostname]] = Regex.scan ~r/hostname: (\w*+)/r,args
+    [[_, interface]] = Regex.scan ~r/--interface=(\w+) /U,args
+    [[_, hostname]] = Regex.scan ~r/hostname: (\w*+)/U,args
     exec_udhcpc(interface, hostname)
   end
 


### PR DESCRIPTION
Fixes deprecation warning in elixir 1.3.x
```
warning: the /r modifier in regular expressions is deprecated, please use /U instead
  (elixir) lib/regex.ex:671: Regex.translate_options/2
  (elixir) lib/regex.ex:112: Regex.compile/2
  (elixir) lib/regex.ex:140: Regex.compile!/2
  (elixir) lib/kernel.ex:4109: Kernel."MACRO-sigil_r"/3
  (elixir) src/elixir_dispatch.erl:185: :elixir_dispatch.expand_macro_fun/6
```