### PR TITLE
Comment didn't get updated when the code changed

### DIFF
--- a/lib/networking/server.ex
+++ b/lib/networking/server.ex
@@ -78,7 +78,7 @@ defmodule Nerves.Networking.Server do
     update_and_announce state, dhcp_retries: retry
   end
 
-  # retry after 10 seconds for the first 10 retries, then 1 min
+  # retry after 15 seconds for the first 10 retries, then 1 min
   defp dhcp_retry_interval(tries) when tries >= 10, do: 60000
   defp dhcp_retry_interval(_tries), do: 15000
 


### PR DESCRIPTION
I noticed that the time-out on line 83 was updated in dfe06c57ae10212f9a44e25cdf575ed8e862d86c but the comment didn't get changed at the same time.