### PR TITLE
Fix type information

### DIFF
--- a/lib/networking.ex
+++ b/lib/networking.ex
@@ -63,9 +63,9 @@ defmodule Nerves.Networking do
 
   alias Nerves.Networking
 
-  @type interface :: Atom
+  @type interface :: Networking.Subsystem.interface
   @type settings :: Dict.t
-  @type reason :: any
+  @type reason :: Networking.Subsystem.interface
 
   def start(_type, _args) do
     Logger.debug "#{__MODULE__} Starting"

--- a/lib/networking/subsystem.ex
+++ b/lib/networking/subsystem.ex
@@ -18,7 +18,7 @@ defmodule Nerves.Networking.Subsystem do
 
   @type reason :: any
   @type ip_address :: String.t
-  @type interface :: String.t
+  @type interface :: String.t | atom
 
   @udhcpc_script_path "/tmp/udhcpc.sh"
   @resolv_conf_path (case Mix.env do


### PR DESCRIPTION
The type for interface refers to the `Atom` module, where one would expect an `atom` type. There is a small inconsistency between the types defined in the `Networking.Subsystem` and in the toplevel `Networking` module. This has been fix by refering to the lower level types where appropriate.

This fix will ensure that a call like:

    Networking.setup :wlan0

will be valid according to Dialyzer.

The current implementation will raise the (vague) message _Function start_network/0 has no local return_ (`start_network` is where `Networking.setup` is called from in this case).